### PR TITLE
Update Galleon Javadoc to English (Resolve Conflict with PT)

### DIFF
--- a/src/main/java/iscteiul/ista/battleship/Galleon.java
+++ b/src/main/java/iscteiul/ista/battleship/Galleon.java
@@ -1,15 +1,36 @@
-/**
- *
- */
 package iscteiul.ista.battleship;
 
+/**
+ * Represents a Galleon ship in the Discoveries Battleship game.
+ * <p>
+ * The Galleon is a large ship with a fixed size of 5 units.
+ * Unlike linear ships, the Galleon occupies a specific geometric structure
+ * that extends across multiple rows and columns, depending on its orientation.
+ * </p>
+ *
+ * @version 1.0
+ */
 public class Galleon extends Ship {
+
+    /**
+     * Fixed size of the Galleon (5 units).
+     */
     private static final Integer SIZE = 5;
+
+    /**
+     * Identifier name of the ship type.
+     */
     private static final String NAME = "Galeao";
 
     /**
-     * @param bearing
-     * @param pos
+     * Constructs a new Galleon with a specific orientation and initial position.
+     * The method calculates the 5 positions occupied by the ship based on the
+     * provided {@code bearing}.
+     *
+     * @param bearing The orientation of the ship (NORTH, SOUTH, EAST, WEST).
+     * @param pos     The reference position (anchor) for placement.
+     * @throws IllegalArgumentException If the bearing is invalid.
+     * @throws NullPointerException     If the bearing is null.
      */
     public Galleon(Compass bearing, IPosition pos) throws IllegalArgumentException {
         super(Galleon.NAME, bearing, pos);
@@ -30,22 +51,27 @@ public class Galleon extends Ship {
             case WEST:
                 fillWest(pos);
                 break;
-
             default:
                 throw new IllegalArgumentException("ERROR! invalid bearing for the galleon");
         }
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Returns the fixed size of the Galleon.
      *
-     * @see battleship.Ship#getSize()
+     * @return The number of occupied cells (5).
+     * @see Ship#getSize()
      */
     @Override
     public Integer getSize() {
         return Galleon.SIZE;
     }
 
+    /**
+     * Fills the ship positions when oriented towards North.
+     *
+     * @param pos Initial position.
+     */
     private void fillNorth(IPosition pos) {
         for (int i = 0; i < 3; i++) {
             getPositions().add(new Position(pos.getRow(), pos.getColumn() + i));
@@ -54,6 +80,11 @@ public class Galleon extends Ship {
         getPositions().add(new Position(pos.getRow() + 2, pos.getColumn() + 1));
     }
 
+    /**
+     * Fills the ship positions when oriented towards South.
+     *
+     * @param pos Initial position.
+     */
     private void fillSouth(IPosition pos) {
         for (int i = 0; i < 2; i++) {
             getPositions().add(new Position(pos.getRow() + i, pos.getColumn()));
@@ -63,6 +94,11 @@ public class Galleon extends Ship {
         }
     }
 
+    /**
+     * Fills the ship positions when oriented towards East.
+     *
+     * @param pos Initial position.
+     */
     private void fillEast(IPosition pos) {
         getPositions().add(new Position(pos.getRow(), pos.getColumn()));
         for (int i = 1; i < 4; i++) {
@@ -71,6 +107,11 @@ public class Galleon extends Ship {
         getPositions().add(new Position(pos.getRow() + 2, pos.getColumn()));
     }
 
+    /**
+     * Fills the ship positions when oriented towards West.
+     *
+     * @param pos Initial position.
+     */
     private void fillWest(IPosition pos) {
         getPositions().add(new Position(pos.getRow(), pos.getColumn()));
         for (int i = 1; i < 4; i++) {


### PR DESCRIPTION
**Summary**
This Pull Request updates the `Galleon` class documentation to match the project's English standard.

**Conflict Scenario:**
* **Main Branch:** Currently contains legacy comments/documentation in **Portuguese**.
* **This Branch:** Contains the new Javadoc in **English**.

**Resolution:**
GitHub detects a conflict because the documentation lines have changed completely.
I will resolve this merge conflict by **accepting the English version** from this branch and overwriting the Portuguese comments in `main`.